### PR TITLE
remove obsoletes from total elements to be coherent with percentage

### DIFF
--- a/potodo/potodo.py
+++ b/potodo/potodo.py
@@ -102,6 +102,7 @@ def exec_potodo(
                 else:
                     print(str(po_file))
             else:
+                tot_num = len(po_file_stats) - len(po_file_stats.obsolete_entries())
                 if fuzzy:
                     if len(po_file_stats.fuzzy_entries()) > 0:
                         if str(po_file).count("/") > 1:
@@ -112,7 +113,7 @@ def exec_potodo(
 
                         buffer.append(
                             f"- {po_file.name:<30} "
-                            + f"{len(po_file_stats.translated_entries()):3d} / {len(po_file_stats):3d} "
+                            + f"{len(po_file_stats.translated_entries()):3d} / {tot_num:3d} "
                             + f"({po_file_stat_percent:5.1f}% translated)"
                             + (
                                 f", {len(po_file_stats.fuzzy_entries())} fuzzy"
@@ -138,7 +139,7 @@ def exec_potodo(
 
                     buffer.append(
                         f"- {po_file.name:<30} "
-                        + f"{len(po_file_stats.translated_entries()):3d} / {len(po_file_stats):3d} "
+                        + f"{len(po_file_stats.translated_entries()):3d} / {tot_num:3d} "
                         + f"({po_file_stat_percent:5.1f}% translated)"
                         + (
                             f", {len(po_file_stats.fuzzy_entries())} fuzzy"


### PR DESCRIPTION
The current output presents each file with:
len(po_file_stats.translated_entries()) / len(po_file_stats) (po_file_stat_percent %)
but po_file_stats contains translated, untranslated, fuzzy AND obsolete entries. The percent value is computed without the obsoletes.
Which gives some files at 100% but, with the number of translated entries below the number of total entries. This looks weird.

The idea of this PR is to fix this by presenting the file with:
len(po_file_stats.translated_entries()) / (len(po_file_stats)-len(po_file_stats.obsolete_entries())) (po_file_stat_percent %)
